### PR TITLE
only add tensorflow as a requirement if it is not already provided

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ requirements = [
 # E.g. tensorflow-gpu
 try:
     import tensorflow
-except ModuleNotFoundError:
+except ImportError:
     requirements.append('tensorflow>=1.0.0')
 
 test_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,15 @@ requirements = [
     'requests>=2.13.0',
     'scipy>=0.18.1',
     'six>=1.10.0',
-    'tensorflow>=1.0.0',
     'Werkzeug>=0.11.15',
 ]
+
+# only add tensorflow as a requirement if it is not already provided.
+# E.g. tensorflow-gpu
+try:
+    import tensorflow
+except ModuleNotFoundError:
+    requirements.append('tensorflow>=1.0.0')
 
 test_requirements = [
     'pytest',


### PR DESCRIPTION
 This catches the case that tensorflow is already provided by something like tensorflow-gpu but it also catches the case that it's already installed.

see #11