### PR TITLE
Add details endpoint to visualizer api

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -79,6 +79,35 @@ Output:
 
 
 
+GET /api/visualizers
+###############
+List all available visualizers
+
+.. code-block:: bash
+
+  curl "localhost:5000/api/visualizers" -b /path/to/cookie -c /path/to/cookie
+
+Output:
+
+.. code-block:: json
+
+  {
+    "visualizers": [
+      {
+        "name": "ClassProbabilities"
+      },
+      {
+        "name": "PartialOcclusion"
+      },
+      {
+        "name": "SaliencyMaps"
+      }
+    ]
+  }
+
+
+
+
 GET /api/visualize
 ###################
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -108,6 +108,54 @@ Output:
 
 
 
+GET /api/visualizers/<vis_name>
+###############
+List all available settings for visualizer ``<viz_name>``
+
+.. code-block:: bash
+
+  curl "localhost:5000/api/visualizers/PartialOcclusion" -b /path/to/cookie -c /path/to/cookie
+
+Output:
+
+.. code-block:: json
+
+  {
+    "settings": {
+      "Occlusion": [
+        "grey",
+        "black",
+        "white"
+      ],
+      "Strides": [
+        "2",
+        "5",
+        "10",
+        "20",
+        "30"
+      ],
+      "Window": [
+        "0.50",
+        "0.40",
+        "0.30",
+        "0.20",
+        "0.10",
+        "0.05"
+      ]
+    }
+  }
+
+returns an empty settings object when no settings available:
+
+.. code-block:: json
+
+  {
+    "settings": {}
+  }
+
+
+
+
 GET /api/visualize
 ###################
 

--- a/picasso/interfaces/rest.py
+++ b/picasso/interfaces/rest.py
@@ -74,6 +74,19 @@ def images():
         return jsonify(images=session['image_list'])
 
 
+@API.route('/visualizers', methods=['GET'])
+def visualizers():
+    """Get a list of available visualizers
+
+    Responses with a JSON list of available visualizers
+
+    """
+    list_of_visualizers = []
+    for visualizer in get_visualizations():
+        list_of_visualizers.append({'name': visualizer})
+    return jsonify(visualizers=list_of_visualizers)
+
+
 @API.route('/visualize', methods=['GET'])
 def visualize():
     """Trigger a visualization via the REST API

--- a/picasso/interfaces/rest.py
+++ b/picasso/interfaces/rest.py
@@ -87,6 +87,17 @@ def visualizers():
     return jsonify(visualizers=list_of_visualizers)
 
 
+@API.route('/visualizers/<vis_name>', methods=['GET'])
+def visualizers_information(vis_name):
+    vis = get_visualizations()[vis_name]
+    if hasattr(vis, 'ALLOWED_SETTINGS'):
+        settings = vis.ALLOWED_SETTINGS
+    else:
+        settings = {}
+
+    return jsonify(settings=settings)
+
+
 @API.route('/visualize', methods=['GET'])
 def visualize():
     """Trigger a visualization via the REST API

--- a/tests/test_picasso.py
+++ b/tests/test_picasso.py
@@ -119,6 +119,16 @@ class TestRestAPI:
         response = client.get(url_for('api.reset'))
         assert response.status_code == 200
 
+    def test_visualizers(self, client):
+        response = client.get(url_for('api.visualizers'))
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize("vis", _get_visualization_classes())
+    def test_visualizers_informations(self, client, vis):
+        response = client.get(url_for('api.visualizers_information', vis_name=vis.__name__))
+        assert response.status_code == 200
+
+
 
 class TestBaseModel:
 


### PR DESCRIPTION
Implements an endpoint to get detailed information for the available visualisers via the REST API.