### PR TITLE
Define contract for visualize json response

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -123,7 +123,8 @@ output:
     "prob": "0.009"
     }
     ],
-    "result_filenames": [
+    "has_output": true
+    "output_file_names": [
     "1496440342.43444780_Image.png",
     "1496440342.6356451_Image.png",
     "1496440342.8196582_Image.png",

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -93,44 +93,42 @@ output:
 .. code-block:: json
 
   {
-    "output": [
-      {
-        "example_filename": "1496440342.3700328Image.png",
-        "input_filename": "Image.png",
-        "predict_probs": [
-          {
-            "index": 2,
-            "name": "2",
-            "prob": "0.769"
-          },
-          {
-            "index": 8,
-            "name": "8",
-            "prob": "0.133"
-          },
-          {
-            "index": 3,
-            "name": "3",
-            "prob": "0.064"
-          },
-          {
-            "index": 7,
-            "name": "7",
-            "prob": "0.012"
-          },
-          {
-            "index": 5,
-            "name": "5",
-            "prob": "0.009"
-          }
-        ],
-        "result_filenames": [
-          "1496440342.43444780_Image.png",
-          "1496440342.6356451_Image.png",
-          "1496440342.8196582_Image.png",
-          "1496440343.0056613_Image.png",
-          "1496440343.1946724_Image.png"
-        ]
-      }
+    {
+    "example_filename": "1496440342.3700328Image.png",
+    "input_filename": "Image.png",
+    "predict_probs": [
+    {
+    "index": 2,
+    "name": "2",
+    "prob": "0.769"
+    },
+    {
+    "index": 8,
+    "name": "8",
+    "prob": "0.133"
+    },
+    {
+    "index": 3,
+    "name": "3",
+    "prob": "0.064"
+    },
+    {
+    "index": 7,
+    "name": "7",
+    "prob": "0.012"
+    },
+    {
+    "index": 5,
+    "name": "5",
+    "prob": "0.009"
+    }
+    ],
+    "result_filenames": [
+    "1496440342.43444780_Image.png",
+    "1496440342.6356451_Image.png",
+    "1496440342.8196582_Image.png",
+    "1496440343.0056613_Image.png",
+    "1496440343.1946724_Image.png"
     ]
+    }
   }

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -95,7 +95,7 @@ output:
   {
     {
     "example_filename": "1496440342.3700328Image.png",
-    "input_filename": "Image.png",
+    "input_file_name": "Image.png",
     "predict_probs": [
     {
     "index": 2,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -93,43 +93,44 @@ output:
 .. code-block:: json
 
   {
-    {
-    "example_filename": "1496440342.3700328Image.png",
-    "input_file_name": "Image.png",
-    "predict_probs": [
-    {
-    "index": 2,
-    "name": "2",
-    "prob": "0.769"
-    },
-    {
-    "index": 8,
-    "name": "8",
-    "prob": "0.133"
-    },
-    {
-    "index": 3,
-    "name": "3",
-    "prob": "0.064"
-    },
-    {
-    "index": 7,
-    "name": "7",
-    "prob": "0.012"
-    },
-    {
-    "index": 5,
-    "name": "5",
-    "prob": "0.009"
-    }
-    ],
-    "has_output": true
+    "has_output": true,
+    "has_processed_input": true,
+    "input_file_name": "test.png",
     "output_file_names": [
-    "1496440342.43444780_Image.png",
-    "1496440342.6356451_Image.png",
-    "1496440342.8196582_Image.png",
-    "1496440343.0056613_Image.png",
-    "1496440343.1946724_Image.png"
-    ]
-    }
+      "1504440185.6014730_test.png",
+      "1504440185.6964661_test.png",
+      "1504440185.7823882_test.png",
+      "1504440185.86981823_test.png",
+      "1504440185.9575094_test.png"
+    ],
+    "predict_probs": [
+      {
+        "index": 8,
+        "name": "8",
+        "prob": "0.171"
+      },
+      {
+        "index": 6,
+        "name": "6",
+        "prob": "0.125"
+      },
+      {
+        "index": 2,
+        "name": "2",
+        "prob": "0.122"
+      },
+      {
+        "index": 5,
+        "name": "5",
+        "prob": "0.119"
+      },
+      {
+        "index": 0,
+        "name": "0",
+        "prob": "0.098"
+      }
+    ],
+    "processed_input_file_name": "1504440185.5588531test.png"
   }
+
+

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -82,7 +82,14 @@ Output:
 GET /api/visualize
 ###################
 
-This endpoint needs at least 2 arguments (``image=X`` and ``visualizer=Y``) in the query string.
+This endpoint needs at least 2 arguments (``image=X`` and ``visualizer=Y``) in the query string. Each response is guaranteed to have at least the following attributes:
+
+=======================   ===================== =========
+``input_file_name``       String
+``predict_probs``         List of probabilities
+``has_output``            boolean               if this is ``True`` the output will also have a list ``output_file_names``
+``has_processed_input``   boolean               if this is ``True`` the output will also have an attribute ``processed_input_file_name``
+=======================   ===================== =========
 
 .. code-block:: bash
 

--- a/picasso/interfaces/rest.py
+++ b/picasso/interfaces/rest.py
@@ -106,7 +106,7 @@ def visualize():
         vis.update_settings(session['settings'])
     output = vis.make_visualization(
         inputs, output_dir=session['img_output_dir'])
-    return jsonify(output=output)
+    return jsonify(output[0])
 
 
 @API.route('/reset', methods=['GET'])

--- a/picasso/templates/PartialOcclusion.html
+++ b/picasso/templates/PartialOcclusion.html
@@ -26,7 +26,7 @@ Contributors:
 						<img src="inputs/{{ result.filename }}" style="width:244px;height:244px;"/>
 					</td>
 					<td align="center">
-						<img src="outputs/{{ result.example_filename }}" style="width:244px;height:244px;"/>
+						<img src="outputs/{{ result.processed_input_file_name }}" style="width:244px;height:244px;"/>
 					</td>
 					{% for filename in result.output_file_names %}
 						<td align="center">

--- a/picasso/templates/PartialOcclusion.html
+++ b/picasso/templates/PartialOcclusion.html
@@ -28,7 +28,7 @@ Contributors:
 					<td align="center">
 						<img src="outputs/{{ result.example_filename }}" style="width:244px;height:244px;"/>
 					</td>
-					{% for filename in result.result_filenames %}
+					{% for filename in result.output_file_names %}
 						<td align="center">
 							<img src="outputs/{{ filename }}" style="width:244px;height:244px;"/>
 						</td>

--- a/picasso/templates/SaliencyMaps.html
+++ b/picasso/templates/SaliencyMaps.html
@@ -24,7 +24,7 @@ Contributors:
 				<td align="center">
 					<img src="inputs/{{ result.filename }}" style="width:244px;height:244px;"/>
 				</td>
-				{% for filename in result.gradient_image_names %}
+				{% for filename in result.output_file_names %}
 					<td align="center">
 						<img src="outputs/{{ filename }}" style="width:244px;height:244px;"/>
 					</td>

--- a/picasso/visualizations/class_probabilities.py
+++ b/picasso/visualizations/class_probabilities.py
@@ -33,5 +33,6 @@ class ClassProbabilities(BaseVisualization):
         results = []
         for i, inp in enumerate(inputs):
             results.append({'input_file_name': inp['filename'],
+                            'has_output': False,
                             'predict_probs': filtered_predictions[i]})
         return results

--- a/picasso/visualizations/class_probabilities.py
+++ b/picasso/visualizations/class_probabilities.py
@@ -34,5 +34,6 @@ class ClassProbabilities(BaseVisualization):
         for i, inp in enumerate(inputs):
             results.append({'input_file_name': inp['filename'],
                             'has_output': False,
+                            'has_processed_input': False,
                             'predict_probs': filtered_predictions[i]})
         return results

--- a/picasso/visualizations/partial_occlusion.py
+++ b/picasso/visualizations/partial_occlusion.py
@@ -109,7 +109,8 @@ class PartialOcclusion(BaseVisualization):
                 predictions, output_dir, example['filename'],
                 decoded_predictions=decoded_predictions[i])
             results.append({'input_file_name': example['filename'],
-                            'result_filenames': filenames,
+                            'has_output': True,
+                            'output_file_names': filenames,
                             'predict_probs': decoded_predictions[i],
                             'example_filename': example_filename})
         return results

--- a/picasso/visualizations/partial_occlusion.py
+++ b/picasso/visualizations/partial_occlusion.py
@@ -112,7 +112,8 @@ class PartialOcclusion(BaseVisualization):
                             'has_output': True,
                             'output_file_names': filenames,
                             'predict_probs': decoded_predictions[i],
-                            'example_filename': example_filename})
+                            'has_processed_input': True,
+                            'processed_input_file_name': example_filename})
         return results
 
     def get_predict_tensor(self):

--- a/picasso/visualizations/partial_occlusion.py
+++ b/picasso/visualizations/partial_occlusion.py
@@ -108,7 +108,7 @@ class PartialOcclusion(BaseVisualization):
             filenames = self.make_heatmaps(
                 predictions, output_dir, example['filename'],
                 decoded_predictions=decoded_predictions[i])
-            results.append({'input_filename': example['filename'],
+            results.append({'input_file_name': example['filename'],
                             'result_filenames': filenames,
                             'predict_probs': decoded_predictions[i],
                             'example_filename': example_filename})

--- a/picasso/visualizations/saliency_maps.py
+++ b/picasso/visualizations/saliency_maps.py
@@ -133,6 +133,7 @@ class SaliencyMaps(BaseVisualization):
             results.append({'input_file_name': inp['filename'],
                             'has_output': True,
                             'predict_probs': decoded_predictions[i],
+                            'has_processed_input': False,
                             'output_file_names': output_fns})
         return results
 

--- a/picasso/visualizations/saliency_maps.py
+++ b/picasso/visualizations/saliency_maps.py
@@ -131,8 +131,9 @@ class SaliencyMaps(BaseVisualization):
                 output_fns.append(output_fn)
 
             results.append({'input_file_name': inp['filename'],
+                            'has_output': True,
                             'predict_probs': decoded_predictions[i],
-                            'gradient_image_names': output_fns})
+                            'output_file_names': output_fns})
         return results
 
     def get_logit_tensor(self):

--- a/tests/test_picasso.py
+++ b/tests/test_picasso.py
@@ -109,9 +109,11 @@ class TestRestAPI:
         response = client.get(url_for('api.visualize') + '?visualizer=' +
                               vis.__name__ +
                               '&image=' + str(upl_data['uid']))
-        data = json.loads(response.get_data(as_text=True))
+        raw_data = response.get_data(as_text=True)
+        data = json.loads(raw_data)
         assert response.status_code == 200
         assert data['input_file_name']
+        assert data['predict_probs']
 
     def test_listing_images(self, client):
         response = client.get(url_for('api.images'))

--- a/tests/test_picasso.py
+++ b/tests/test_picasso.py
@@ -116,6 +116,8 @@ class TestRestAPI:
         assert data['predict_probs']
         if data['has_output']:
             assert data['output_file_names']
+        if data['has_processed_input']:
+            assert data['processed_input_file_name']
 
     def test_listing_images(self, client):
         response = client.get(url_for('api.images'))

--- a/tests/test_picasso.py
+++ b/tests/test_picasso.py
@@ -114,6 +114,8 @@ class TestRestAPI:
         assert response.status_code == 200
         assert data['input_file_name']
         assert data['predict_probs']
+        if data['has_output']:
+            assert data['output_file_names']
 
     def test_listing_images(self, client):
         response = client.get(url_for('api.images'))

--- a/tests/test_picasso.py
+++ b/tests/test_picasso.py
@@ -109,7 +109,9 @@ class TestRestAPI:
         response = client.get(url_for('api.visualize') + '?visualizer=' +
                               vis.__name__ +
                               '&image=' + str(upl_data['uid']))
+        data = json.loads(response.get_data(as_text=True))
         assert response.status_code == 200
+        assert data['input_file_name']
 
     def test_listing_images(self, client):
         response = client.get(url_for('api.images'))


### PR DESCRIPTION
This pull Request adds a contract for all responses served via `/api/visualize`. It makes it easier for consumers of the API to rely on a specific structure. The unit tests make sure that also future visualisers adhere to this contract.

If the contract cannot fulfil the need of a future visualiser then we need to extend the contract. However, I tried to be generic with the naming of the attributes to allow for maximum flexibility. If there is even a better way to call the attributes please comment on it. I am by no means an expert of CNN visualisation.

For now the contract consists of 4 attributes that a consumer can rely on:

| name | type | notes |
| --- | --- | --- |
| ``input_file_name`` | String | |
| ``predict_probs`` | List | |
| ``has_output`` | boolean | if this is ``True`` the output will also have a list ``output_file_names`` |
| ``has_processed_input`` | boolean | if this is ``True`` the output will also have an attribute ``processed_input_file_name`` |
